### PR TITLE
Add paginated query results and rendering

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,2 @@
-#DATABASE_URL=postgresql://postgres:password@localhost/solaceassignment
+DATABASE_URL=postgresql://postgres:password@localhost/solaceassignment
+MOCK_DB_DATA=false

--- a/DISCUSSION.md
+++ b/DISCUSSION.md
@@ -2,8 +2,12 @@
 We have a DB of potentially 100k's of Advocates. Our users need to be able to view and search through that large list in an easy and optimal way; we don't want to force them to think. 
 
 
-Follow-up Optimizations:
+Follow-up Features & Optimizations:
+- Unit tests (BE + FE)  
+- Add FE Error handling for displaying user friendly error msgs
+- Format phone numbers when displayed in table
+- Revalidate cache for /advocates path when advocates upserted or deleted
+- Input Validation (Zod library)
 - Add db indexes to columns (top contenders: first_name, last_name, city )
-   - (Research GIN indexes for specialties column of JSONB for faster LIKE searches )
-- Pagination on table to handle displaying 100k's of results
-- Unit tests (BE + FE)
+   - (Research GIN indexes for 'specialties' column of JSONB for faster LIKE searches)
+-

--- a/src/app/api/advocates/route.ts
+++ b/src/app/api/advocates/route.ts
@@ -1,12 +1,117 @@
-import db from "../../../db";
-import { advocates } from "../../../db/schema";
-import { advocateData } from "../../../db/seed/advocates";
+import db from '../../../db'
+import { advocates } from '../../../db/schema'
+import { advocateData } from '../../../db/seed/advocates'
+import { dbDefaultLimit, dbDefaultOffset } from '../../../utils'
+import { sql } from 'drizzle-orm'
 
-export async function GET() {
-  // Uncomment this line to use a database
-  // const data = await db.select().from(advocates);
+export async function GET(request: Request) {
+  const { searchTerm, limit, offset } = extractQueryParams(request)
 
-  const data = advocateData;
+  const useMockData = process.env.MOCK_DB_DATA || !process.env.DATABASE_URL
+  if (useMockData) {
+    const data = simulateMockPaginatedQuery(limit, offset, searchTerm)
+    return Response.json({ data })
+  }
 
-  return Response.json({ data });
+  try {
+    let data
+    if (!!searchTerm) {
+      data = await fetchAdvocatesWithSearchTerm(searchTerm, limit, offset)
+    } else {
+      data = await fetchAdvocates(limit, offset)
+    }
+    return Response.json({ data })
+  } catch (error: any) {
+    console.error(error)
+    return Response.json({ error: 'Internal server error' }, { status: 500 })
+  }
+}
+
+/**
+ * Fetch paginated batch of advocates w/ search term & return total count of advocates
+ * that match the search term in the db
+ */
+async function fetchAdvocatesWithSearchTerm(
+  searchTerm: string,
+  limit: number,
+  offset: number
+) {
+  return db
+    .select({
+      ...advocates,
+      totalCount: sql<number>`count(*) over()`,
+    })
+    .from(advocates)
+    .where(
+      sql`LOWER(${advocates.firstName}) LIKE LOWER(${`%${searchTerm}%`}) OR 
+          LOWER(${advocates.lastName}) LIKE LOWER(${`%${searchTerm}%`}) OR 
+          LOWER(${advocates.city}) LIKE LOWER(${`%${searchTerm}%`}) OR 
+          LOWER(${advocates.degree}) LIKE LOWER(${`%${searchTerm}%`}) OR 
+          LOWER(${
+            advocates.specialties
+          }::text) LIKE LOWER(${`%${searchTerm}%`}) OR
+          LOWER(${
+            advocates.yearsOfExperience
+          }::text) LIKE LOWER(${`%${searchTerm}%`})`
+    )
+    .limit(limit)
+    .offset(offset)
+}
+
+/**
+ * Fetch paginated batch of advocates & return total count of advocates in db
+ */
+async function fetchAdvocates(limit: number, offset: number) {
+  return db
+    .select({
+      ...advocates,
+      totalCount: sql<number>`count(*) over()`,
+    })
+    .from(advocates)
+    .limit(limit)
+    .offset(offset)
+}
+
+function extractQueryParams(request: Request) {
+  const { searchParams } = new URL(request.url)
+  const limit = searchParams.get('limit')
+    ? Number(searchParams.get('limit'))
+    : dbDefaultLimit
+  const offset = searchParams.get('offset')
+    ? Number(searchParams.get('offset'))
+    : dbDefaultOffset
+  const searchTerm = searchParams.get('searchTerm')
+    ? searchParams.get('searchTerm')
+    : ''
+
+  return { searchTerm, limit, offset }
+}
+
+// Mock our paginated db query on mock advocate data for UI pagination functionality
+function simulateMockPaginatedQuery(
+  limit: number,
+  offset: number,
+  searchTerm: string | null
+) {
+  let data = advocateData
+  if (!!searchTerm) {
+    data = data.filter((advocate) => {
+      return (
+        advocate.firstName.toLowerCase().includes(searchTerm.toLowerCase()) ||
+        advocate.lastName.toLowerCase().includes(searchTerm.toLowerCase()) ||
+        advocate.city.toLowerCase().includes(searchTerm.toLowerCase()) ||
+        advocate.degree.toLowerCase().includes(searchTerm.toLowerCase()) ||
+        advocate.specialties.some((specialty: string) =>
+          specialty.toLowerCase().includes(searchTerm.toLowerCase())
+        ) ||
+        advocate.yearsOfExperience.toString().includes(searchTerm)
+      )
+    })
+  }
+  data = data.map((advocate) => ({
+    ...advocate,
+    totalCount: data.length,
+  }))
+  data = data.slice(offset, offset + limit)
+  return data
 }

--- a/src/app/components/table.tsx
+++ b/src/app/components/table.tsx
@@ -2,64 +2,75 @@
 
 import { useState, useEffect } from "react";
 import type { Advocate } from "../../db/schema";
+import { dbDefaultLimit, API_BASE_URL, dbDefaultOffset } from "@/utils";
+import { getAdvocates } from "../services/advocatesService";
 
-export interface TableProps { }
+export interface TableProps {
+  initialAdvocates: Advocate[];
+  initialTotalCount: number;
+}
 
-export default function Table(props: TableProps) {
-  const [advocates, setAdvocates] = useState([]);
-  const [filteredAdvocates, setFilteredAdvocates] = useState([]);
+export default function Table({ initialAdvocates, initialTotalCount }: TableProps) {
+  const [filteredAdvocates, setFilteredAdvocates] = useState(initialAdvocates);
+  const [currentPage, setCurrentPage] = useState(0);
+  const [searchTerm, setSearchTerm] = useState("");
+  const [totalCount, setTotalCount] = useState(initialTotalCount);
 
   useEffect(() => {
-    async function fetchAdvocates() {
-      const advocatesResponse = await fetch("/api/advocates")
-      const advocatesJson = await advocatesResponse.json()
-      setAdvocates(advocatesJson.data);
-      setFilteredAdvocates(advocatesJson.data);
-    }
-    fetchAdvocates();
-  }, []);
+    updateAdvocates();
+  }, [currentPage]);
+  
+  /**
+   *  currentPage & searchTerm state hooks may not update in time for query, so we pass in _currentPage & _searchTerm as an override if necessary
+   * */
+  const updateAdvocates = async ({_currentPage, _searchTerm}: {_currentPage?: number, _searchTerm?: string} = {}) => {
+    const offset = _currentPage ? _currentPage * dbDefaultLimit : currentPage * dbDefaultLimit;
+    const {data: updatedAdvocates, totalCount: updatedTotalCount} = await getAdvocates(dbDefaultLimit, offset, _searchTerm ?? searchTerm);
+    setFilteredAdvocates(updatedAdvocates);
+    setTotalCount(updatedTotalCount);
+  }
 
   const onSearchInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const searchTerm = e.target.value;
+    const inputValue = e.target.value;
     const searchTermElement: HTMLSpanElement | null = document.getElementById("search-term") as HTMLSpanElement;
     if (searchTermElement) {
-      searchTermElement.innerHTML = searchTerm;
+      searchTermElement.innerHTML = inputValue;
     }
-    const filteredAdvocates = advocates.filter((advocate: Advocate) => {
-      return (
-        advocate.firstName.toLowerCase().includes(searchTerm.toLowerCase()) ||
-        advocate.lastName.toLowerCase().includes(searchTerm.toLowerCase()) ||
-        advocate.city.toLowerCase().includes(searchTerm.toLowerCase()) ||
-        advocate.degree.toLowerCase().includes(searchTerm.toLowerCase()) ||
-        advocate.specialties.some((s: string) => s.toLowerCase().includes(searchTerm.toLowerCase())) ||
-        advocate.yearsOfExperience.toString().toLowerCase().includes(searchTerm.toLowerCase())
-      );
-    });
-    setFilteredAdvocates(filteredAdvocates); 
+    setSearchTerm(inputValue);
   };
 
-  const onClickSearchButton = () => {
-    setFilteredAdvocates(advocates);
+  const onClickSearchButton = async () => {
+    setCurrentPage(0);
+    await updateAdvocates({_currentPage: 0});
   };
 
-  const onClickResetButton = () => {
-    setFilteredAdvocates(advocates);
+  const onClickResetButton = async () => {
+    setCurrentPage(0);
+    setSearchTerm("");
+    const searchTermElement: HTMLSpanElement | null = document.getElementById("search-term") as HTMLSpanElement;
+    if (searchTermElement) {
+      searchTermElement.innerHTML = "";
+    }
+    await updateAdvocates({_currentPage: 0, _searchTerm: ""});
   };
 
   return (
     <>
       <div>
-      <p>Search</p>
-      <p>
-        Searching for: <span id="search-term"></span>
-      </p>
-      <input style={{ border: "1px solid black" }} onChange={onSearchInputChange} />
-      <button className="border border-gray-400 rounded-md mx-2 px-2" onClick={onClickResetButton}>Reset</button>
-      <button className="border border-gray-400 rounded-md mx-2 px-2" onClick={onClickSearchButton}>Search</button>
-    </div>
-    <br />
-    <br />
-    <table className="min-w-full border border-gray-200 rounded-lg">
+        <p>Search</p>
+        <p>
+          Searching for: <span id="search-term"></span>
+        </p>
+        <input value={searchTerm} style={{ border: "1px solid black" }} 
+          onChange={onSearchInputChange} 
+          onKeyDown={(e) => e.key === 'Enter' && onClickSearchButton()}
+        />
+        <button className="border border-gray-400 rounded-md mx-2 px-2 active:scale-95 transition-transform duration-100" onClick={onClickResetButton}>Reset</button>
+        <button className="border border-gray-400 rounded-md mx-2 px-2 active:scale-95 transition-transform duration-100" onClick={onClickSearchButton}>Search</button>
+      </div>
+      <br />
+      <br />
+      <table className="min-w-full border border-gray-200 rounded-lg">
         <thead className="bg-gray-50">
           <tr>
             <th className="border-b px-6 py-3 text-left">First Name</th>
@@ -70,27 +81,63 @@ export default function Table(props: TableProps) {
             <th className="border-b px-6 py-3 text-left">Years of Experience</th>
             <th className="border-b px-6 py-3 text-left">Phone Number</th>
           </tr>
-          </thead>
-          <tbody className="divide-y divide-gray-200">
-            {filteredAdvocates.map((advocate: Advocate, index: number) => {
-              return (
-                <tr key={`${advocate.id}-${index}`}>
-                  <td className="px-6 py-4">{advocate.firstName}</td>
-                  <td className="px-6 py-4">{advocate.lastName}</td>
-                  <td className="px-6 py-4">{advocate.city}</td>
-                  <td className="px-6 py-4">{advocate.degree}</td>
-                  <td className="px-6 py-4">
-                    {advocate.specialties.map((s, index) => (
-                      <div key={`${advocate.id}-${s}-${index}`}>{s}</div>
-                    ))}
-                  </td>
-                  <td className="px-6 py-4">{advocate.yearsOfExperience}</td>
-                  <td className="px-6 py-4">{advocate.phoneNumber}</td>
-                </tr>
+        </thead>
+        <tbody className="divide-y divide-gray-200">
+          {filteredAdvocates.map((advocate: Advocate, index: number) => {
+            return (
+              <tr key={`${advocate.id}-${index}`}>
+                <td className="px-6 py-4">{advocate.firstName}</td>
+                <td className="px-6 py-4">{advocate.lastName}</td>
+                <td className="px-6 py-4">{advocate.city}</td>
+                <td className="px-6 py-4">{advocate.degree}</td>
+                <td className="px-6 py-4">
+                  {advocate.specialties.map((s, index) => (
+                    <div key={`${advocate.id}-${s}-${index}`}>{s}</div>
+                  ))}
+                </td>
+                <td className="px-6 py-4">{advocate.yearsOfExperience}</td>
+                <td className="px-6 py-4">{advocate.phoneNumber}</td>
+              </tr>
             );
           })}
         </tbody>
       </table>
+      <PaginationControls 
+        currentPage={currentPage} 
+        setCurrentPage={setCurrentPage} 
+        totalCount={totalCount}
+      />
     </>
   );
+}
+
+interface PaginationControlsProps {
+  currentPage: number;
+  setCurrentPage: React.Dispatch<React.SetStateAction<number>>;
+  totalCount: number;
+}
+
+function PaginationControls({ currentPage, setCurrentPage, totalCount }: PaginationControlsProps){
+  return(
+    <div className="mt-4 flex items-center justify-between px-6">
+      <button
+        onClick={() => setCurrentPage((prev) => prev - 1)}
+        disabled={currentPage === 0}
+        className="px-4 py-2 border border-gray-400 rounded-md disabled:opacity-50"
+      >
+        Previous
+      </button>
+      <span>
+        Page {totalCount > 0 ? currentPage + 1 : 0} of{' '}
+        {Math.ceil(totalCount / dbDefaultLimit)}
+      </span>
+      <button
+        onClick={() => setCurrentPage((prev) => prev + 1)}
+        disabled={currentPage >= Math.ceil(totalCount / dbDefaultLimit) - 1}
+        className="px-4 py-2 border border-gray-400 rounded-md disabled:opacity-50"
+      >
+        Next
+      </button>
+    </div>
+  )
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,12 +1,15 @@
 import Table from "./components/table";
+import { dbDefaultLimit, dbDefaultOffset, API_BASE_URL } from "@/utils";
+import { getAdvocates } from "./services/advocatesService";
 
-export default function Home() {
+export default async function Home() {
+  const { data: initialAdvocates, totalCount } = await getAdvocates(dbDefaultLimit, dbDefaultOffset);
   return (
     <main style={{ margin: "24px" }}>
       <h1>Solace Advocates</h1>
       <br />
       <br />
-      <Table />
+      <Table initialAdvocates={initialAdvocates} initialTotalCount={totalCount} />
     </main>
   );
 }

--- a/src/app/services/advocatesService.ts
+++ b/src/app/services/advocatesService.ts
@@ -1,0 +1,31 @@
+import { API_BASE_URL } from '@/utils'
+
+const ONE_MINUTE = 60
+
+/**
+ * Fetch paginated batch of advocates from the backend
+ * Caches the response for 1 minute before revalidating
+ */
+export async function getAdvocates(
+  limit: number,
+  offset: number,
+  searchTerm: string = ''
+) {
+  const queryUrl = `${API_BASE_URL}/advocates?limit=${limit}&offset=${offset}&searchTerm=${searchTerm}`
+  try {
+    const res = await fetch(queryUrl, { next: { revalidate: ONE_MINUTE } })
+    const resJson = await res.json()
+    return {
+      data: resJson.data,
+      totalCount:
+        resJson?.data.length > 0 ? Number(resJson.data[0].totalCount) : 0,
+    }
+  } catch (error: any) {
+    console.error(error.message)
+    return {
+      error: error.message,
+      data: [],
+      totalCount: 0,
+    }
+  }
+}

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -1,20 +1,37 @@
-import { drizzle } from "drizzle-orm/postgres-js";
-import postgres from "postgres";
+import { drizzle } from 'drizzle-orm/postgres-js'
+import postgres from 'postgres'
 
 const setup = () => {
-  if (!process.env.DATABASE_URL) {
-    console.error("DATABASE_URL is not set");
+  // Hacky temp workaround so the mock db can chain limit(), offset(), where() when envvars not set
+  // This helps avoid type errors during development and allows us to 'run npm run build'
+  // TODO: Refactor a cleaner mock - possibly use envvars to check if local or prod instead
+  if (!process.env.DATABASE_URL || process.env.MOCK_DB_DATA) {
+    console.error('DATABASE_URL is not set or MOCK_DB_DATA is true')
     return {
-      select: () => ({
-        from: () => [],
+      select: (q?: any) => ({
+        from: () => ({
+          limit: (n: number) => ({
+            offset: (m: number) => [],
+          }),
+          where: (q?: any) => ({
+            limit: (n: number) => ({
+              offset: (m: number) => [],
+            }),
+          }),
+        }),
       }),
-    };
+      insert: (q?: any) => ({
+        values: (q?: any) => ({
+          returning: (q?: any) => [],
+        }),
+      }),
+    }
   }
 
   // for query purposes
-  const queryClient = postgres(process.env.DATABASE_URL);
-  const db = drizzle(queryClient);
-  return db;
-};
+  const queryClient = postgres(process.env.DATABASE_URL)
+  const db = drizzle(queryClient)
+  return db
+}
 
-export default setup();
+export default setup()

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -30,6 +30,7 @@ export interface Advocate {
   specialties: string[];
   yearsOfExperience: number;
   phoneNumber: string;
+  totalCount: number;
 }
 
 export { advocates };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,3 @@
+export const dbDefaultLimit = 5
+export const dbDefaultOffset = 0
+export const API_BASE_URL = 'http://localhost:3000/api'


### PR DESCRIPTION
## Description
 One assumptions were working with is that the db has 100k's of entries in the advocates table.  The initial state of the app returned a universal SELECT query to the db, which returns all advocates to the front end. Let's do some back of the napkin math to see what that could come out to data-wise.
 - Advocates table columns:
   - id: 4 bytes
   - firstName: ~8 bytes (assuming avg of 8 chars)
   - lastName: ~8 bytes
   - city: ~8 bytes
   - degree: ~8 bytes
   - specialties: ~24 bytes
   - yearsofExperience: 4 bytes (int)
   - phoneNumber: 8 bytes (bigint)
   - createdAt: 8 bytes (timestampt)
   - db row overhead: ~20 bytes
   - Total: ~100 bytes
- Lets assume 900k rows:
  -  900k * 100bytes = 90 MB
  - Returning 90Mb's per request to each user on page load is unreasonably large for what this app does, not to mention that users experience with perhaps network speed, browsers holding that in memory, and displaying all that on screens(such as mobile). 

 This PR introduces pagination + rendering on the front end and paginated requests to the backend for Advocates data. This is a better approach to fetching and displaying data to our users from a large amount of db data. The search input also also allows searching based on search terms, along with the pagination. 

Other changes such as basic error handling around fetch calls and db calls introduced; updated db queries;

## Changes Made
- [x] Pagination + navigation to front end UI
- [x] Paginated request/queries to the DB
- [x] Mock db data refactored to simulate paginated responses
- [x] Search term functionality integrated w/ paginated requests
- [x] Error handling 
- [x] Home page(server component) makes init request for advocates
 

## Screenshots
<img width="1715" alt="image" src="https://github.com/user-attachments/assets/59286b44-9ad1-40cf-81f7-dc072e07ef01" />

 

## Notes 
Certain initial features were removed or moved to other locations in the code base. The initial filtering of advocates was moved from the front end to the backend in the db query. The dynamic searching of advocates based on characters added to the search input was removed and replaced with general search term functionality from the backend db query; the dynamic searching feature could be a follow up PR (at the expense of much more db requests; keystroke debouncing could augment that);
 